### PR TITLE
[SHIPIT-0714] initial PagerDuty + SNS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+## `pagerduty`
+
+A PagerDuty service that’s associated with an escalation policy.
+
+| attribute (req)                   | type   | description                                         |
+|-----------------------------------|--------|-----------------------------------------------------|
+| `escalation_policy`**req**        | string | a PagerDuty escalation policy                       |
+| `auto_resolve_timeout` **req**    | number | seconds until alert is resolved                     |
+| `acknowledgement_timeout` **req** | number | seconds until alert is escalated                    |
+| `alert_action` **req**            | string | action to take (e.g. `create_incident`)             |
+| `rule` **req**                    | map    |                                                     |
+| — `type` **req**                  | string | either `constant` (any time) or `use_support_hours` |
+| — `urgency` **req**               | string | either `low` (no escalation) or `high` (escalation) |
+
+These are specified as map with each key being an escalation level:
+
+```hcl-terraform
+module "emergency" {
+	pagerduty = {
+		critical = {
+			escalation_policy = "..."
+			auto_resolve_timeout = 86400
+			acknowledgement_timeout = 600
+			alert_action = "create_incident"
+			rule = {
+				type = "constant"
+				urgency = "high"
+			}
+		}
+	}
+}
+```
+
+## `pagerduty_integrations`
+
+TODO

--- a/main.tf
+++ b/main.tf
@@ -29,19 +29,19 @@ resource "pagerduty_service" "pagerduty" {
 
 # generates a pagerduty service that receives an integration key that
 # SNS subscriptions can use to hit PagerDuty
-resource "pagerduty_service_integration" "pagerduty_service" {
+resource "pagerduty_service_integration" "services" {
   count   = length(local.services)
   name    = local.services[ count.index ][ "vendor_name" ]
   vendor  = local.services[ count.index ][ "vendor_id" ]
-  service = pagerduty_service[ local.services[ count.index ][ "escalation_level" ] ][ "id" ]
+  service = pagerduty_service.pagerduty[ local.services[ count.index ][ "escalation_level" ] ][ "id" ]
 }
 
 # connects each pagerduty_service to its SNS escalation level
-resource "aws_sns_topic_subscription" "pagerduty_sns" {
+resource "aws_sns_topic_subscription" "pagerduty_subscriptions" {
   count                           = length(local.services)
   topic_arn                       = aws_sns_topic.topics[ local.services[ count.index ][ "escalation_level" ] ][ "arn" ]
   protocol                        = "https"
-  endpoint                        = "https://events.pagerduty.com/integration/${pagerduty_service_integration["pagerduty_service"][count.index]["integration_key"]}/enqueue"
+  endpoint                        = "https://events.pagerduty.com/integration/${pagerduty_service_integration.services[count.index]["integration_key"]}/enqueue"
   endpoint_auto_confirms          = local.services[ count.index ]["subscription"][ "auto_confirm" ]
   confirmation_timeout_in_minutes = local.services[ count.index ]["subscription"][ "confirm_timeout" ]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,35 @@
+locals {
+  prefix = var.name_prefix
+  tags   = var.tags
+
+  escalation_levels  = var.escalation_levels
+  pagerduty          = var.pagerduty
+  pagerduty_services = var.pagerduty_services != null ? var.pagerduty_services : [ ]
+}
+
+resource "aws_sns_topic" "sns_escalation_levels" {
+  for_each = toset(local.escalation_levels)
+  name     = "${local.prefix}-SNS-${title(each.value)}"
+  tags     = local.tags
+}
+
+resource "pagerduty_service" "pagerduty" {
+  for_each                = local.pagerduty
+  name                    = "${local.prefix}-PagerDuty-${each.key}"
+  auto_resolve_timeout    = each.value[ "auto_resolve_timeout" ]
+  acknowledgement_timeout = each.value[ "acknowledgement_timeout" ]
+  alert_creation          = each.value[ "alert_action" ]
+  escalation_policy       = each.value[ "escalation_policy" ]
+
+  incident_urgency_rule {
+    type    = each.value[ "rule" ][ "type" ]
+    urgency = each.value[ "rule" ][ "urgency" ]
+  }
+}
+
+resource "pagerduty_service_integration" "pagerduty_service" {
+  for_each = local.pagerduty_services
+  name     = each.value[ "vendor_name" ]
+  vendor   = each.value[ "vendor_id" ]
+  service  = pagerduty_service[ each.value[ "escalation_level" ] ][ "id" ]
+}

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
   services           = var.pagerduty_services != null ? var.pagerduty_services : [ ]
 }
 
-resource "aws_sns_topic" "sns_escalation_levels" {
+resource "aws_sns_topic" "topics" {
   for_each = toset(local.escalation_levels)
   name     = "${local.prefix}-SNS-${title(each.value)}"
   tags     = local.tags
@@ -39,7 +39,7 @@ resource "pagerduty_service_integration" "pagerduty_service" {
 # connects each pagerduty_service to its SNS escalation level
 resource "aws_sns_topic_subscription" "pagerduty_sns" {
   count                           = length(local.services)
-  topic_arn                       = aws_sns_topic[ local.services[ count.index ][ "escalation_level" ] ][ "arn" ]
+  topic_arn                       = aws_sns_topic.topics[ local.services[ count.index ][ "escalation_level" ] ][ "arn" ]
   protocol                        = "https"
   endpoint                        = "https://events.pagerduty.com/integration/${pagerduty_service_integration["pagerduty_service"][count.index]["integration_key"]}/enqueue"
   endpoint_auto_confirms          = local.services[ count.index ]["subscription"][ "auto_confirm" ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,5 @@
+output "sns_topic_arns" {
+  value = {for key, sns in aws_sns_topic.topics:
+    key => sns.arn
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -25,10 +25,10 @@ variable "pagerduty" {
       urgency = string
     })
   }))
-  description = "Defines PagerDuty integration where each key corresponds to an escalation level value."
+  description = "Defines a PagerDuty service associated with an escalation policy. Each key must correspond to a value in `escalation_levels`"
 }
 
-variable "pagerduty_services" {
+variable "pagerduty_integrations" {
   type        = list(object({
     vendor_name      = string
     vendor_id        = string
@@ -39,5 +39,5 @@ variable "pagerduty_services" {
     })
   }))
   default     = [ ]
-  description = "Specify list of services that hook into PagerDuty alerts"
+  description = "Adds integrations from other services to PagerDuty through an SNS subscription"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "escalation_levels" {
 variable "pagerduty" {
   type        = map(object({
     escalation_policy       = string
-    auto_resolve_timout     = number
+    auto_resolve_timeout    = number
     acknowledgement_timeout = number
     alert_action            = string
     rule                    = object({
@@ -33,11 +33,11 @@ variable "pagerduty_services" {
     vendor_name      = string
     vendor_id        = string
     escalation_level = string
-    subscription = object({
-      auto_confirm     = bool
-      confirm_timeout  = number
+    subscription     = object({
+      auto_confirm    = bool
+      confirm_timeout = number
     })
   }))
-  default = []
+  default     = [ ]
   description = "Specify list of services that hook into PagerDuty alerts"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,38 @@
+variable "name_prefix" {
+  type        = string
+  description = "The prefix to append to all resource names"
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Tags to apply to resources"
+  default     = {}
+}
+
+variable "escalation_levels" {
+  type        = list(string)
+  description = "Define your escalation levels, e.g.: [critical, urgent, non-critical]"
+}
+
+variable "pagerduty" {
+  type        = map(object({
+    escalation_policy       = string
+    auto_resolve_timout     = number
+    acknowledgement_timeout = number
+    alert_action            = string
+    rule                    = object({
+      type    = string
+      urgency = string
+    })
+  }))
+  description = "A map where each key corresponds to an escalation level value."
+}
+
+variable "pagerduty_services" {
+  type        = list(object({
+    vendor_name      = string
+    vendor_id        = string
+    escalation_level = string
+  }))
+  description = "Specify list of services that hook into PagerDuty alerts"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "pagerduty" {
       urgency = string
     })
   }))
-  description = "A map where each key corresponds to an escalation level value."
+  description = "Defines PagerDuty integration where each key corresponds to an escalation level value."
 }
 
 variable "pagerduty_services" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,11 @@ variable "pagerduty_services" {
     vendor_name      = string
     vendor_id        = string
     escalation_level = string
+    subscription = object({
+      auto_confirm     = bool
+      confirm_timeout  = number
+    })
   }))
+  default = []
   description = "Specify list of services that hook into PagerDuty alerts"
 }


### PR DESCRIPTION
module creates the following resources:

- sns topics by escalation level (e.g. `non-critical`, `critical`)
- pagerduty services associated with escalation level
- pagerduty integrations that subscribe to a service via sns topic