### PR TITLE
[SHIPIT-0715] fix varnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ These are specified as map with each key being an escalation level:
 
 ```hcl-terraform
 module "emergency" {
+    source = "." 
 	pagerduty = {
 		critical = {
 			escalation_policy = "..."


### PR DESCRIPTION
incorrectly expected var `pagerduty_services` instead of `pagerduty_integrations`; changed a couple of internal names